### PR TITLE
Enforce scoped auth for EPCIS MCP tools

### DIFF
--- a/.codex/review-prompt.md
+++ b/.codex/review-prompt.md
@@ -26,19 +26,21 @@ When both exist, report blockers first.
 
 Do three passes:
 
-1. **Context + risk-map pass (mandatory)** — Read full touched files (not only hunk lines) and identify high-risk zones: platform/runtime boundaries, event handlers, async cleanup (`finally`), auth/validation boundaries, and repeated predicates/guards.
+1. **Context + risk-map pass (mandatory)** — Start from diff hunks, then read surrounding or full touched files when needed to evaluate maintainability, coupling, naming, and extraction opportunities. Use this context to assess changed behavior, not to run unrelated file-wide audits.
 2. **Blockers pass** — Scan for correctness bugs, security issues, API/schema contract breaks, missing migrations, data integrity risks, and missing tests for changed behavior. These are `🔴 Bug` comments.
 3. **Maintainability pass** — Scan for code bloat, readability issues, naming problems, pattern violations, hardcoded values, and architecture drift in touched areas. These are `🟡 Issue`, `🔵 Nit`, or `💡 Suggestion` comments.
 
 ### Comment Gate
 
-Before posting any comment, verify all three conditions:
+Before posting any comment, verify all four conditions:
 
 1. **Introduced by this diff** — The issue is introduced or materially worsened by the changes in this PR, not pre-existing.
 2. **Materially impactful** — The issue affects correctness, security, readability, or maintainability in a meaningful way. Not a theoretical concern.
 3. **Concrete fix direction** — You can suggest a specific fix or clear direction. If you can only say "this seems off" without a concrete suggestion, do not comment.
+4. **Scope fit** — If the issue is mainly in pre-existing code, the PR must touch the same function/module and fixing it must directly simplify, de-risk, or de-duplicate the new/changed code.
 
 If any check fails, skip the comment.
+Every comment must be traceable to changed behavior in this PR and anchored to a right-side line present in `pr-diff.patch`. Prefer added/modified lines; use nearby unchanged hunk lines only when necessary to explain a directly related issue.
 
 **Uncertainty guard:** If you are not certain an issue is real and cannot verify it from the diff and allowed context, do not label it `🔴 Bug`. Downgrade to `🟡 Issue` or `💡 Suggestion`, or skip it entirely.
 
@@ -135,7 +137,9 @@ Do not flag one-off numeric literals that are self-explanatory in context (e.g.,
 - Type annotations for code that already type-checks.
 - Things that are clearly intentional design choices backed by existing patterns.
 - Pre-existing issues in unchanged code outside the diff.
+- Pre-existing issues in touched files when the PR does not introduce/worsen them.
 - Adding documentation unless a public API is clearly undocumented.
+- Repository-wide or file-wide audits not required by the changed behavior.
 
 ## Comment Format
 

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -75,7 +75,8 @@ jobs:
               }
             );
 
-            // Build set of valid (path:line) pairs from diff patches
+            // Build set of valid (path:line) pairs from right-side diff hunk lines
+            // (added + context). This keeps comments bound to changed areas.
             const validLines = new Set();
             for (const file of files) {
               // Skip binary/large/truncated files with no patch
@@ -89,20 +90,26 @@ jobs:
                   currentLine = parseInt(hunkMatch[1], 10);
                   continue;
                 }
-                // Deleted lines don't exist in the new file
-                if (line.startsWith('-')) continue;
-                // Context lines and added lines are valid targets
-                if (!line.startsWith('\\')) {
+                // Added lines are valid comment targets
+                if (line.startsWith('+')) {
                   validLines.add(`${file.filename}:${currentLine}`);
                   currentLine++;
+                  continue;
                 }
+                // Deleted lines don't exist in the new file
+                if (line.startsWith('-')) continue;
+                // Ignore hunk metadata lines
+                if (line.startsWith('\\')) continue;
+                // Context lines on the right side are also valid targets
+                validLines.add(`${file.filename}:${currentLine}`);
+                currentLine++;
               }
             }
 
-            // Partition comments into valid (on diff lines) and overflow
+            // Partition comments into valid (on right-side diff lines) and dropped
             const comments = Array.isArray(review.comments) ? review.comments : [];
             const validComments = [];
-            const overflowComments = [];
+            const droppedComments = [];
 
             for (const comment of comments) {
               const key = `${comment.path}:${comment.line}`;
@@ -114,19 +121,13 @@ jobs:
                   side: 'RIGHT',
                 });
               } else {
-                overflowComments.push(comment);
+                droppedComments.push(comment);
               }
             }
 
-            // Build review body: summary + any overflow comments
+            // Build review body from summary only.
+            // Intentionally do NOT publish out-of-diff comments.
             let body = review.summary || 'Codex review complete.';
-            if (overflowComments.length > 0) {
-              body += '\n\n### Additional comments\n';
-              body += '_These comments target lines outside the diff and could not be posted inline._\n\n';
-              for (const c of overflowComments) {
-                body += `- **\`${c.path}:${c.line}\`** — ${c.body}\n`;
-              }
-            }
 
             // Post the review
             await github.rest.pulls.createReview({
@@ -138,4 +139,4 @@ jobs:
               comments: validComments,
             });
 
-            console.log(`Review posted: ${validComments.length} inline comments, ${overflowComments.length} overflow comments`);
+            console.log(`Review posted: ${validComments.length} inline comments, ${droppedComments.length} dropped out-of-diff comments`);

--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@dkg/expo-forcegraph": "^0.0.0",
     "@dkg/plugin-dkg-essentials": "^0.0.3",
+    "@dkg/plugin-epcis": "^0.0.1",
     "@dkg/plugin-example": "^0.0.3",
     "@dkg/plugin-oauth": "^0.0.2",
     "@dkg/plugin-swagger": "^0.0.2",
@@ -55,7 +56,6 @@
     "better-sqlite3": "^12.2.0",
     "dkg.js": "^8.2.2",
     "dotenv": "^16.3.1",
-    "mysql2": "^3.6.5",
     "drizzle-orm": "^0.44.7",
     "expo": "53.0.20",
     "expo-blur": "~14.1.5",
@@ -77,6 +77,7 @@
     "expo-three": "^8.0.0",
     "expo-web-browser": "~14.2.0",
     "js-sha256": "^0.11.1",
+    "mysql2": "^3.6.5",
     "nodemailer": "^7.0.6",
     "prompts": "^2.4.2",
     "react": "19.0.0",

--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@dkg/expo-forcegraph": "^0.0.0",
     "@dkg/plugin-dkg-essentials": "^0.0.3",
-    "@dkg/plugin-epcis": "^0.0.1",
     "@dkg/plugin-example": "^0.0.3",
     "@dkg/plugin-oauth": "^0.0.2",
     "@dkg/plugin-swagger": "^0.0.2",

--- a/apps/agent/src/server/index.ts
+++ b/apps/agent/src/server/index.ts
@@ -3,7 +3,6 @@ import { createPluginServer, defaultPlugin } from "@dkg/plugins";
 import { authorized, createOAuthPlugin } from "@dkg/plugin-oauth";
 import dkgEssentialsPlugin from "@dkg/plugin-dkg-essentials";
 import createFsBlobStorage from "@dkg/plugin-dkg-essentials/createFsBlobStorage";
-import epcisPlugin, { applyEpcisHttpScopeGuards } from "@dkg/plugin-epcis";
 import examplePlugin from "@dkg/plugin-example";
 import swaggerPlugin from "@dkg/plugin-swagger";
 //@ts-expect-error No types for dkg.js ...
@@ -108,7 +107,6 @@ const app = createPluginServer({
     defaultPlugin,
     oauthPlugin,
     (_, __, api) => {
-      applyEpcisHttpScopeGuards(api, authorized);
       api.use("/mcp", authorized(["mcp"]));
       api.use("/mcp", (req, res, next) => {
         if (res.locals.auth) {
@@ -130,7 +128,6 @@ const app = createPluginServer({
     },
     accountManagementPlugin,
     dkgEssentialsPlugin,
-    epcisPlugin,
     examplePlugin.withNamespace("protected", {
       middlewares: [authorized(["scope123"])], // Allow only users with the "scope123" scope
     }),

--- a/apps/agent/src/server/index.ts
+++ b/apps/agent/src/server/index.ts
@@ -3,6 +3,7 @@ import { createPluginServer, defaultPlugin } from "@dkg/plugins";
 import { authorized, createOAuthPlugin } from "@dkg/plugin-oauth";
 import dkgEssentialsPlugin from "@dkg/plugin-dkg-essentials";
 import createFsBlobStorage from "@dkg/plugin-dkg-essentials/createFsBlobStorage";
+import epcisPlugin from "@dkg/plugin-epcis";
 import examplePlugin from "@dkg/plugin-example";
 import swaggerPlugin from "@dkg/plugin-swagger";
 //@ts-expect-error No types for dkg.js ...
@@ -32,7 +33,14 @@ const version = "1.0.0";
 const { oauthPlugin, openapiSecurityScheme } = createOAuthPlugin({
   storage: new SqliteOAuthStorageProvider(db),
   issuerUrl: new URL(process.env.EXPO_PUBLIC_MCP_URL),
-  scopesSupported: ["mcp", "llm", "scope123", "blob"],
+  scopesSupported: [
+    "mcp",
+    "llm",
+    "scope123",
+    "blob",
+    "epcis.read",
+    "epcis.write",
+  ],
   loginPageUrl: new URL(process.env.EXPO_PUBLIC_APP_URL + "/login"),
   schema: userCredentialsSchema,
   async login(credentials) {
@@ -100,7 +108,17 @@ const app = createPluginServer({
     defaultPlugin,
     oauthPlugin,
     (_, __, api) => {
+      api.get("/epcis/events", authorized(["epcis.read"]));
+      api.get("/epcis/events/track", authorized(["epcis.read"]));
+      api.get("/epcis/capture/:captureID", authorized(["epcis.write"]));
+      api.post("/epcis/capture", authorized(["epcis.write"]));
       api.use("/mcp", authorized(["mcp"]));
+      api.use("/mcp", (req, res, next) => {
+        if (res.locals.auth) {
+          (req as any).auth = res.locals.auth;
+        }
+        next();
+      });
       api.use("/llm", authorized(["llm"]));
       api.use("/blob", authorized(["blob"]));
       api.use("/change-password", authorized([]));
@@ -115,6 +133,7 @@ const app = createPluginServer({
     },
     accountManagementPlugin,
     dkgEssentialsPlugin,
+    epcisPlugin,
     examplePlugin.withNamespace("protected", {
       middlewares: [authorized(["scope123"])], // Allow only users with the "scope123" scope
     }),

--- a/apps/agent/src/server/index.ts
+++ b/apps/agent/src/server/index.ts
@@ -3,7 +3,7 @@ import { createPluginServer, defaultPlugin } from "@dkg/plugins";
 import { authorized, createOAuthPlugin } from "@dkg/plugin-oauth";
 import dkgEssentialsPlugin from "@dkg/plugin-dkg-essentials";
 import createFsBlobStorage from "@dkg/plugin-dkg-essentials/createFsBlobStorage";
-import epcisPlugin from "@dkg/plugin-epcis";
+import epcisPlugin, { applyEpcisHttpScopeGuards } from "@dkg/plugin-epcis";
 import examplePlugin from "@dkg/plugin-example";
 import swaggerPlugin from "@dkg/plugin-swagger";
 //@ts-expect-error No types for dkg.js ...
@@ -108,10 +108,7 @@ const app = createPluginServer({
     defaultPlugin,
     oauthPlugin,
     (_, __, api) => {
-      api.get("/epcis/events", authorized(["epcis.read"]));
-      api.get("/epcis/events/track", authorized(["epcis.read"]));
-      api.get("/epcis/capture/:captureID", authorized(["epcis.write"]));
-      api.post("/epcis/capture", authorized(["epcis.write"]));
+      applyEpcisHttpScopeGuards(api, authorized);
       api.use("/mcp", authorized(["mcp"]));
       api.use("/mcp", (req, res, next) => {
         if (res.locals.auth) {

--- a/apps/agent/tests/integration/setup/test-server.ts
+++ b/apps/agent/tests/integration/setup/test-server.ts
@@ -3,6 +3,7 @@ import { createPluginServer, defaultPlugin } from "@dkg/plugins";
 import { authorized, createOAuthPlugin } from "@dkg/plugin-oauth";
 import dkgEssentialsPlugin from "@dkg/plugin-dkg-essentials";
 import createFsBlobStorage from "@dkg/plugin-dkg-essentials/createFsBlobStorage";
+import epcisPlugin from "@dkg/plugin-epcis";
 import {
   createInMemoryBlobStorage,
   createMockDkgClient,
@@ -84,7 +85,14 @@ export async function createTestServer(config: TestServerConfig = {}): Promise<{
   const { oauthPlugin, openapiSecurityScheme } = createOAuthPlugin({
     storage: testDatabase.oauthStorage,
     issuerUrl: new URL(oauthUrls.issuerUrl),
-    scopesSupported: ["mcp", "llm", "scope123", "blob"],
+    scopesSupported: [
+      "mcp",
+      "llm",
+      "scope123",
+      "blob",
+      "epcis.read",
+      "epcis.write",
+    ],
     loginPageUrl: new URL(oauthUrls.loginPageUrl),
     schema: userCredentialsSchema,
     async login(credentials: { email: string; password: string }) {
@@ -149,7 +157,17 @@ export async function createTestServer(config: TestServerConfig = {}): Promise<{
       oauthPlugin,
       // Same authorization middleware as real app
       (_, __, api) => {
+        api.get("/epcis/events", authorized(["epcis.read"]));
+        api.get("/epcis/events/track", authorized(["epcis.read"]));
+        api.get("/epcis/capture/:captureID", authorized(["epcis.write"]));
+        api.post("/epcis/capture", authorized(["epcis.write"]));
         api.use("/mcp", authorized(["mcp"]));
+        api.use("/mcp", (req, res, next) => {
+          if (res.locals.auth) {
+            (req as any).auth = res.locals.auth;
+          }
+          next();
+        });
         api.use("/llm", authorized(["llm"]));
         api.use("/blob", authorized(["blob"]));
       },
@@ -161,6 +179,7 @@ export async function createTestServer(config: TestServerConfig = {}): Promise<{
         });
       },
       dkgEssentialsPlugin,
+      epcisPlugin,
       // DKG Publisher Plugin for API contract testing
       mockDkgPublisherPlugin, // Mock version - tests interfaces without database
       // Test the namespace functionality

--- a/apps/agent/tests/integration/setup/test-server.ts
+++ b/apps/agent/tests/integration/setup/test-server.ts
@@ -3,7 +3,7 @@ import { createPluginServer, defaultPlugin } from "@dkg/plugins";
 import { authorized, createOAuthPlugin } from "@dkg/plugin-oauth";
 import dkgEssentialsPlugin from "@dkg/plugin-dkg-essentials";
 import createFsBlobStorage from "@dkg/plugin-dkg-essentials/createFsBlobStorage";
-import epcisPlugin from "@dkg/plugin-epcis";
+import epcisPlugin, { applyEpcisHttpScopeGuards } from "@dkg/plugin-epcis";
 import {
   createInMemoryBlobStorage,
   createMockDkgClient,
@@ -157,10 +157,7 @@ export async function createTestServer(config: TestServerConfig = {}): Promise<{
       oauthPlugin,
       // Same authorization middleware as real app
       (_, __, api) => {
-        api.get("/epcis/events", authorized(["epcis.read"]));
-        api.get("/epcis/events/track", authorized(["epcis.read"]));
-        api.get("/epcis/capture/:captureID", authorized(["epcis.write"]));
-        api.post("/epcis/capture", authorized(["epcis.write"]));
+        applyEpcisHttpScopeGuards(api, authorized);
         api.use("/mcp", authorized(["mcp"]));
         api.use("/mcp", (req, res, next) => {
           if (res.locals.auth) {
@@ -251,6 +248,7 @@ export async function startTestServer(config: TestServerConfig = {}): Promise<{
 
       const actualPort = (server.address() as any)?.port || port;
       const url = `http://localhost:${actualPort}`;
+      process.env.EXPO_PUBLIC_MCP_URL = url;
 
       console.log(`Test server running at ${url}`);
 

--- a/apps/agent/tests/integration/workflows/epcis-authorization.spec.ts
+++ b/apps/agent/tests/integration/workflows/epcis-authorization.spec.ts
@@ -1,0 +1,315 @@
+import { expect } from "chai";
+import request from "supertest";
+import { startTestServer } from "../setup/test-server";
+import {
+  callMcpTool,
+  createTestToken,
+  initializeMcpSession,
+} from "../setup/test-helpers";
+
+function parseMcpPayload(result: any): Record<string, any> {
+  const firstContent = result.result?.content?.[0];
+  if (!firstContent?.text) return {};
+  return JSON.parse(firstContent.text);
+}
+
+describe("EPCIS Authorization Integration", () => {
+  let testServer: Awaited<ReturnType<typeof startTestServer>>;
+
+  beforeEach(async function () {
+    this.timeout(15000);
+    testServer = await startTestServer();
+  });
+
+  afterEach(async () => {
+    if (testServer?.cleanup) {
+      await testServer.cleanup();
+    }
+  });
+
+  describe("Missing token handling", () => {
+    it("returns 401 for EPCIS API and MCP transport without token", async () => {
+      await request(testServer.app)
+        .get("/epcis/events")
+        .query({ bizStep: "receiving" })
+        .expect(401);
+
+      await request(testServer.app)
+        .post("/mcp")
+        .set("Accept", "application/json, text/event-stream")
+        .set("Content-Type", "application/json")
+        .send({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "epcis-auth-test", version: "1.0.0" },
+          },
+        })
+        .expect(401);
+    });
+  });
+
+  describe("MCP-only token", () => {
+    it("denies EPCIS MCP tools with 403-equivalent payload", async () => {
+      const mcpOnlyToken = await createTestToken(
+        testServer,
+        ["mcp"],
+        "epcis-mcp-only",
+      );
+      const sessionId = await initializeMcpSession(
+        testServer.app,
+        mcpOnlyToken,
+      );
+
+      const readResult = await callMcpTool(
+        testServer.app,
+        mcpOnlyToken,
+        sessionId,
+        "epcis-query",
+        { bizStep: "receiving" },
+      );
+      const readPayload = parseMcpPayload(readResult);
+
+      expect(readResult.result.isError).to.equal(true);
+      expect(readPayload.error).to.equal("Forbidden");
+      expect(readPayload.statusCode).to.equal(403);
+      expect(readPayload.requiredScope).to.equal("epcis.read");
+
+      const writeResult = await callMcpTool(
+        testServer.app,
+        mcpOnlyToken,
+        sessionId,
+        "epcis-capture",
+        {
+          epcisDocument: { type: "NotAnEPCIS" },
+        },
+      );
+      const writePayload = parseMcpPayload(writeResult);
+
+      expect(writeResult.result.isError).to.equal(true);
+      expect(writePayload.error).to.equal("Forbidden");
+      expect(writePayload.statusCode).to.equal(403);
+      expect(writePayload.requiredScope).to.equal("epcis.write");
+
+      const statusResult = await callMcpTool(
+        testServer.app,
+        mcpOnlyToken,
+        sessionId,
+        "epcis-capture-status",
+        { captureID: "123" },
+      );
+      const statusPayload = parseMcpPayload(statusResult);
+      expect(statusResult.result.isError).to.equal(true);
+      expect(statusPayload.error).to.equal("Forbidden");
+      expect(statusPayload.statusCode).to.equal(403);
+      expect(statusPayload.requiredScope).to.equal("epcis.write");
+    });
+  });
+
+  describe("Read-only scope", () => {
+    it("allows event reads and denies capture/status for API and MCP", async () => {
+      const apiReadToken = await createTestToken(
+        testServer,
+        ["epcis.read"],
+        "epcis-api-read-only",
+      );
+      await request(testServer.app)
+        .get("/epcis/events")
+        .set("Authorization", `Bearer ${apiReadToken}`)
+        .query({ bizStep: "receiving" })
+        .expect(200);
+      await request(testServer.app)
+        .post("/epcis/capture")
+        .set("Authorization", `Bearer ${apiReadToken}`)
+        .send({ epcisDocument: { type: "NotAnEPCIS" } })
+        .expect(403);
+      await request(testServer.app)
+        .get("/epcis/capture/123")
+        .set("Authorization", `Bearer ${apiReadToken}`)
+        .expect(403);
+
+      const mcpReadToken = await createTestToken(
+        testServer,
+        ["mcp", "epcis.read"],
+        "epcis-mcp-read-only",
+      );
+      const sessionId = await initializeMcpSession(
+        testServer.app,
+        mcpReadToken,
+      );
+
+      const readResult = await callMcpTool(
+        testServer.app,
+        mcpReadToken,
+        sessionId,
+        "epcis-query",
+        { bizStep: "receiving" },
+      );
+      expect(readResult.result.isError).to.not.equal(true);
+
+      const writeResult = await callMcpTool(
+        testServer.app,
+        mcpReadToken,
+        sessionId,
+        "epcis-capture",
+        { epcisDocument: { type: "NotAnEPCIS" } },
+      );
+      const writePayload = parseMcpPayload(writeResult);
+      expect(writeResult.result.isError).to.equal(true);
+      expect(writePayload.error).to.equal("Forbidden");
+      expect(writePayload.statusCode).to.equal(403);
+
+      const statusResult = await callMcpTool(
+        testServer.app,
+        mcpReadToken,
+        sessionId,
+        "epcis-capture-status",
+        { captureID: "123" },
+      );
+      const statusPayload = parseMcpPayload(statusResult);
+      expect(statusResult.result.isError).to.equal(true);
+      expect(statusPayload.error).to.equal("Forbidden");
+      expect(statusPayload.statusCode).to.equal(403);
+      expect(statusPayload.requiredScope).to.equal("epcis.write");
+    });
+  });
+
+  describe("Write-only scope", () => {
+    it("allows capture/status and denies event reads for API and MCP", async () => {
+      const apiWriteToken = await createTestToken(
+        testServer,
+        ["epcis.write"],
+        "epcis-api-write-only",
+      );
+      await request(testServer.app)
+        .post("/epcis/capture")
+        .set("Authorization", `Bearer ${apiWriteToken}`)
+        .send({ epcisDocument: { type: "NotAnEPCIS" } })
+        .expect(400);
+      await request(testServer.app)
+        .get("/epcis/events")
+        .set("Authorization", `Bearer ${apiWriteToken}`)
+        .query({ bizStep: "receiving" })
+        .expect(403);
+      await request(testServer.app)
+        .get("/epcis/capture/123")
+        .set("Authorization", `Bearer ${apiWriteToken}`)
+        .then((response) => {
+          expect(response.status).to.not.equal(401);
+          expect(response.status).to.not.equal(403);
+        });
+
+      const mcpWriteToken = await createTestToken(
+        testServer,
+        ["mcp", "epcis.write"],
+        "epcis-mcp-write-only",
+      );
+      const sessionId = await initializeMcpSession(
+        testServer.app,
+        mcpWriteToken,
+      );
+
+      const captureResult = await callMcpTool(
+        testServer.app,
+        mcpWriteToken,
+        sessionId,
+        "epcis-capture",
+        { epcisDocument: { type: "NotAnEPCIS" } },
+      );
+      const capturePayload = parseMcpPayload(captureResult);
+      expect(captureResult.result.isError).to.equal(true);
+      expect(capturePayload.error).to.equal("Invalid EPCISDocument");
+
+      const statusResult = await callMcpTool(
+        testServer.app,
+        mcpWriteToken,
+        sessionId,
+        "epcis-capture-status",
+        { captureID: "123" },
+      );
+      const statusPayload = parseMcpPayload(statusResult);
+      expect(statusResult.result.isError).to.equal(true);
+      expect(statusPayload.error).to.not.equal("Forbidden");
+
+      const readResult = await callMcpTool(
+        testServer.app,
+        mcpWriteToken,
+        sessionId,
+        "epcis-query",
+        { bizStep: "receiving" },
+      );
+      const readPayload = parseMcpPayload(readResult);
+      expect(readResult.result.isError).to.equal(true);
+      expect(readPayload.error).to.equal("Forbidden");
+      expect(readPayload.statusCode).to.equal(403);
+    });
+  });
+
+  describe("Read + write scopes", () => {
+    it("allows all EPCIS paths (auth pass) for API and MCP", async () => {
+      const apiToken = await createTestToken(
+        testServer,
+        ["epcis.read", "epcis.write"],
+        "epcis-api-read-write",
+      );
+      await request(testServer.app)
+        .get("/epcis/events")
+        .set("Authorization", `Bearer ${apiToken}`)
+        .query({ bizStep: "receiving" })
+        .expect(200);
+      await request(testServer.app)
+        .post("/epcis/capture")
+        .set("Authorization", `Bearer ${apiToken}`)
+        .send({ epcisDocument: { type: "NotAnEPCIS" } })
+        .expect(400);
+      await request(testServer.app)
+        .get("/epcis/capture/123")
+        .set("Authorization", `Bearer ${apiToken}`)
+        .then((response) => {
+          expect(response.status).to.not.equal(401);
+          expect(response.status).to.not.equal(403);
+        });
+
+      const mcpToken = await createTestToken(
+        testServer,
+        ["mcp", "epcis.read", "epcis.write"],
+        "epcis-mcp-read-write",
+      );
+      const sessionId = await initializeMcpSession(testServer.app, mcpToken);
+
+      const readResult = await callMcpTool(
+        testServer.app,
+        mcpToken,
+        sessionId,
+        "epcis-query",
+        { bizStep: "receiving" },
+      );
+      expect(readResult.result.isError).to.not.equal(true);
+
+      const captureResult = await callMcpTool(
+        testServer.app,
+        mcpToken,
+        sessionId,
+        "epcis-capture",
+        { epcisDocument: { type: "NotAnEPCIS" } },
+      );
+      const capturePayload = parseMcpPayload(captureResult);
+      expect(captureResult.result.isError).to.equal(true);
+      expect(capturePayload.error).to.equal("Invalid EPCISDocument");
+
+      const statusResult = await callMcpTool(
+        testServer.app,
+        mcpToken,
+        sessionId,
+        "epcis-capture-status",
+        { captureID: "123" },
+      );
+      const statusPayload = parseMcpPayload(statusResult);
+      expect(statusResult.result.isError).to.equal(true);
+      expect(statusPayload.error).to.not.equal("Forbidden");
+    });
+  });
+});

--- a/apps/agent/tests/integration/workflows/epcis-authorization.spec.ts
+++ b/apps/agent/tests/integration/workflows/epcis-authorization.spec.ts
@@ -78,6 +78,19 @@ describe("EPCIS Authorization Integration", () => {
       expect(readPayload.statusCode).to.equal(403);
       expect(readPayload.requiredScope).to.equal("epcis.read");
 
+      const trackItemResult = await callMcpTool(
+        testServer.app,
+        mcpOnlyToken,
+        sessionId,
+        "epcis-track-item",
+        { epc: "urn:epc:id:sgtin:4012345.011111.1001" },
+      );
+      const trackItemPayload = parseMcpPayload(trackItemResult);
+      expect(trackItemResult.result.isError).to.equal(true);
+      expect(trackItemPayload.error).to.equal("Forbidden");
+      expect(trackItemPayload.statusCode).to.equal(403);
+      expect(trackItemPayload.requiredScope).to.equal("epcis.read");
+
       const writeResult = await callMcpTool(
         testServer.app,
         mcpOnlyToken,
@@ -150,6 +163,15 @@ describe("EPCIS Authorization Integration", () => {
       );
       expect(readResult.result.isError).to.not.equal(true);
 
+      const trackItemResult = await callMcpTool(
+        testServer.app,
+        mcpReadToken,
+        sessionId,
+        "epcis-track-item",
+        { epc: "urn:epc:id:sgtin:4012345.011111.1001" },
+      );
+      expect(trackItemResult.result.isError).to.not.equal(true);
+
       const writeResult = await callMcpTool(
         testServer.app,
         mcpReadToken,
@@ -197,9 +219,10 @@ describe("EPCIS Authorization Integration", () => {
       await request(testServer.app)
         .get("/epcis/capture/123")
         .set("Authorization", `Bearer ${apiWriteToken}`)
-        .then((response) => {
-          expect(response.status).to.not.equal(401);
-          expect(response.status).to.not.equal(403);
+        .expect(404)
+        .expect(({ body }) => {
+          expect(body.error).to.equal("Capture not found");
+          expect(body.captureID).to.equal("123");
         });
 
       const mcpWriteToken = await createTestToken(
@@ -232,7 +255,21 @@ describe("EPCIS Authorization Integration", () => {
       );
       const statusPayload = parseMcpPayload(statusResult);
       expect(statusResult.result.isError).to.equal(true);
-      expect(statusPayload.error).to.not.equal("Forbidden");
+      expect(statusPayload.error).to.equal("Capture not found");
+      expect(statusPayload.captureID).to.equal("123");
+
+      const trackItemResult = await callMcpTool(
+        testServer.app,
+        mcpWriteToken,
+        sessionId,
+        "epcis-track-item",
+        { epc: "urn:epc:id:sgtin:4012345.011111.1001" },
+      );
+      const trackItemPayload = parseMcpPayload(trackItemResult);
+      expect(trackItemResult.result.isError).to.equal(true);
+      expect(trackItemPayload.error).to.equal("Forbidden");
+      expect(trackItemPayload.statusCode).to.equal(403);
+      expect(trackItemPayload.requiredScope).to.equal("epcis.read");
 
       const readResult = await callMcpTool(
         testServer.app,
@@ -268,9 +305,10 @@ describe("EPCIS Authorization Integration", () => {
       await request(testServer.app)
         .get("/epcis/capture/123")
         .set("Authorization", `Bearer ${apiToken}`)
-        .then((response) => {
-          expect(response.status).to.not.equal(401);
-          expect(response.status).to.not.equal(403);
+        .expect(404)
+        .expect(({ body }) => {
+          expect(body.error).to.equal("Capture not found");
+          expect(body.captureID).to.equal("123");
         });
 
       const mcpToken = await createTestToken(
@@ -288,6 +326,15 @@ describe("EPCIS Authorization Integration", () => {
         { bizStep: "receiving" },
       );
       expect(readResult.result.isError).to.not.equal(true);
+
+      const trackItemResult = await callMcpTool(
+        testServer.app,
+        mcpToken,
+        sessionId,
+        "epcis-track-item",
+        { epc: "urn:epc:id:sgtin:4012345.011111.1001" },
+      );
+      expect(trackItemResult.result.isError).to.not.equal(true);
 
       const captureResult = await callMcpTool(
         testServer.app,
@@ -309,7 +356,8 @@ describe("EPCIS Authorization Integration", () => {
       );
       const statusPayload = parseMcpPayload(statusResult);
       expect(statusResult.result.isError).to.equal(true);
-      expect(statusPayload.error).to.not.equal("Forbidden");
+      expect(statusPayload.error).to.equal("Capture not found");
+      expect(statusPayload.captureID).to.equal("123");
     });
   });
 });

--- a/docs/build-a-dkg-node-ai-agent/customizing-your-dkg-agent.md
+++ b/docs/build-a-dkg-node-ai-agent/customizing-your-dkg-agent.md
@@ -36,11 +36,9 @@ Your plugin comes pre-scaffolded with examples that show how to expose a tool bo
 
 <figure><img src="../.gitbook/assets/Screenshot 2025-11-05 at 14.40.17.png" alt=""><figcaption></figcaption></figure>
 
-Within the `defineDkgPlugin` module, on line 6 we expose the plugin code via an MCP tool through `mcp.registerTool()`  and on line 50 the plugin exposes a classic HTTP API, in this case a GET route, via  `api.get()`&#x20;
+Within the `defineDkgPlugin` module, on line 6 we expose the plugin code via an MCP tool through `mcp.registerTool()` and on line 50 the plugin exposes a classic HTTP API, in this case a GET route, via `api.get()`&#x20;
 
 We recommend writing your custom plugin logic in your custom functions, like `yourCustomFunction` above, then use it within the `mcp.registerTool()` and `api.get()` code block.
-
-
 
 1.  **(Optional) Add dependencies**
 
@@ -49,9 +47,10 @@ We recommend writing your custom plugin logic in your custom functions, like `yo
     ```
 
     Run this inside your `plugin-<your-name>` directory.
-2. **(optional) Add additional source files if needed (e.g., utils.ts)**
-   * Place them in the `src/` directory.
-   * Import them into your `index.ts`.
+
+2.  **(optional) Add additional source files if needed (e.g., utils.ts)**
+    - Place them in the `src/` directory.
+    - Import them into your `index.ts`.
 3.  **Once your are done, make sure to build your plugin by running**
 
     ```bash
@@ -63,6 +62,7 @@ We recommend writing your custom plugin logic in your custom functions, like `yo
     ```bash
     turbo build
     ```
+
 4.  **Install your plugin in the DKG Node Agent**
 
     ```bash
@@ -71,6 +71,7 @@ We recommend writing your custom plugin logic in your custom functions, like `yo
     ```
 
     This package name is auto-generated (check `packages/plugin-<your-name>/package.json`).
+
 5.  **Make sure to import your plugin and register it through** `createPluginServer`\
     \
     Open `apps/agent/src/server/index.ts` and add:
@@ -87,12 +88,13 @@ We recommend writing your custom plugin logic in your custom functions, like `yo
         examplePlugin.withNamespace("protected", {
           middlewares: [authorized(["scope123"])],
         }),
-        
+
         // Add your own plugin here
         myCustomPlugin,
       ],
     });
     ```
+
 6.  **Run your DKG Node Agent**
 
     Start the agent from the project root folder and run `npm run dev` . Test that your plugin is registered and working
@@ -112,11 +114,13 @@ If you want to create your plugin outside of the monorepo and manage it as your 
     ```
 
     (or use an existing project)
+
 2.  **Add "@dkg/plugins" package as a dependency**
 
     ```bash
     npm install --save @dkg/plugins
     ```
+
 3.  **Define your plugin**
 
     ```ts
@@ -125,13 +129,13 @@ If you want to create your plugin outside of the monorepo and manage it as your 
     const myCustomPlugin = defineDkgPlugin((ctx, mcp, api) => {
       // Example MCP tool
       // mcp.registerTool("my-mcp-tool", ... );
-
       // Example API route
       // api.get("/my-get-route", (req, res) => ... );
     });
 
     export default myCustomPlugin;
     ```
+
 4.  **(Optional) Add configuration support**\
     You can export your plugin as a function that accepts options:
 
@@ -139,8 +143,9 @@ If you want to create your plugin outside of the monorepo and manage it as your 
     const configurablePlugin = (options: {...}) =>
       defineDkgPlugin((ctx, mcp, api) => { ... });
     ```
-5. **(Optional) Publish to npm**
-   * Run `npm publish` to share with the DKG builder community.
+
+5.  **(Optional) Publish to npm**
+    - Run `npm publish` to share with the DKG builder community.
 
 {% hint style="warning" %}
 💡**Tip:** See how the already existing plugins are created by looking into existing plugin packages in the monorepo, e.g `packages/plugin-auth` and `packages/plugin-example`.
@@ -151,22 +156,22 @@ If you want to create your plugin outside of the monorepo and manage it as your 
 DKG plugins are **functions** applied in the order you register them.\
 While you _can_ define inline functions, using `defineDkgPlugin` is recommended for:
 
-* **Type-safety**
-* **Extension methods**
+- **Type-safety**
+- **Extension methods**
 
 #### `defineDkgPlugin` arguments
 
 When you define a plugin, the DKG Node automatically injects three objects:
 
 1. **`ctx` (Context)**
-   * `ctx.logger` → Logger instance for logging messages
-   * `ctx.dkg` → DKG Client instance for interacting with the DKG network
+   - `ctx.logger` → Logger instance for logging messages
+   - `ctx.dkg` → DKG Client instance for interacting with the DKG network
 2. **`mcp` (MCP Server)**
-   * An instance of the MCP Server from `@modelcontextprotocol/sdk`
-   * Use it to register MCP tools and resources
+   - An instance of the MCP Server from `@modelcontextprotocol/sdk`
+   - Use it to register MCP tools and resources
 3. **`api` (API Server)**
-   * Express server instance from the express npm package
-   * Use it to expose REST API routes from your plugin
+   - Express server instance from the express npm package
+   - Use it to expose REST API routes from your plugin
 
 All registered routes and MCP tools become part of the **DKG Node API server**.
 
@@ -184,13 +189,36 @@ mcp.registerTool(
   {
     title: "Tool name",
     description: "Tool description",
-    inputSchema: { /* expected input variables and format */ },
+    inputSchema: {
+      /* expected input variables and format */
+    },
   },
   // YOUR TOOL CODE HERE
 );
 ```
 
+If your MCP tool needs scope-based authorization, use the same `mcp.registerTool(...)` API and wrap the handler with `withRequiredMcpScope`:
+
+```ts
+import { withRequiredMcpScope } from "@dkg/plugins";
+
+mcp.registerTool(
+  "my-protected-tool",
+  {
+    title: "Protected tool",
+    description: "Runs only when required scope is present",
+    inputSchema: {},
+  },
+  withRequiredMcpScope("my.scope", async (input, context) => {
+    // Put your real tool logic here (call services, validate input, query APIs, etc.).
+    // this is just an example response shape.
+    return { content: [{ type: "text", text: "ok" }] };
+  }),
+);
+```
+
 {% hint style="success" %}
+
 #### Including source Knowledge Assets in your MCP tool responses
 
 When building custom tools for your DKG Node Agent, you can attach **Source Knowledge Assets** to any MCP tool response, allowing the DKG Node Agent (and other agents you might use with your DKG Node) to display which Knowledge Assets were used to form the answer.
@@ -202,7 +230,7 @@ See the [Source Knowledge Assets in tool responses](https://app.gitbook.com/o/-M
 
 Expose routes through the API server for more “traditional” API calls.
 
-**Example of how to expose tools through API routes** **(auto-scaffolded  by `turbo gen plugin`):**
+**Example of how to expose tools through API routes** **(auto-scaffolded by `turbo gen plugin`):**
 
 ```ts
 api.get("/ROUTE_NAME", (req, res) => {
@@ -213,12 +241,12 @@ api.get("/ROUTE_NAME", (req, res) => {
 💡 **Tip: Test your API routes with Swagger**\
 When your DKG Node is running, all exposed API routes are automatically documented and testable via the Swagger UI:
 
-* Open [http://localhost:9200/swagger](http://localhost:9200/swagger)
-* You’ll see:
-  * All registered API routes
-  * Descriptions (from your route/tool definitions)
-  * Input/output schemas (from your route/tool definitions)
-  * Ability to **test requests directly in the browser**
+- Open [http://localhost:9200/swagger](http://localhost:9200/swagger)
+- You’ll see:
+  - All registered API routes
+  - Descriptions (from your route/tool definitions)
+  - Input/output schemas (from your route/tool definitions)
+  - Ability to **test requests directly in the browser**
 
 This makes it easy to confirm your plugin’s routes are working as expected.
 
@@ -264,9 +292,9 @@ import myCustomPlugin from "@dkg/plugin-<your-name>";
 
 #### Notes
 
-* `.withNamespace("...")` is optional — it scopes your plugin’s routes/tools under a namespace and lets you attach middlewares (e.g., auth/permissions) - more on that in the [Configure access & security](broken-reference) section&#x20;
-* All registered **MCP tools** and **API routes** from your plugins are exposed via the DKG Node API.
-* You can combine inline plugins and imported packages in the same `plugins` array.
+- `.withNamespace("...")` is optional — it scopes your plugin’s routes/tools under a namespace and lets you attach middlewares (e.g., auth/permissions) - more on that in the [Configure access & security](broken-reference) section&#x20;
+- All registered **MCP tools** and **API routes** from your plugins are exposed via the DKG Node API.
+- You can combine inline plugins and imported packages in the same `plugins` array.
 
 #### Run & verify
 
@@ -277,4 +305,3 @@ npm run dev
 ```
 
 (from the root folder) 🎉
-

--- a/docs/build-a-dkg-node-ai-agent/plugins/epcis-plugin.md
+++ b/docs/build-a-dkg-node-ai-agent/plugins/epcis-plugin.md
@@ -7,7 +7,7 @@ It provides both HTTP endpoints and MCP tools for:
 - capturing EPCIS documents
 - checking capture status
 - querying events with filters
-- retrieving published assets by UAL
+- tracking an item journey with full traceability
 
 ## Source
 
@@ -15,11 +15,18 @@ It provides both HTTP endpoints and MCP tools for:
 - Query service: `packages/plugin-epcis/src/services/epcisQueryService.ts`
 - Integration guide: `packages/plugin-epcis/docs/EPCIS-Integration-Guide.md`
 
+## Runtime state in this repository
+
+- The current main server setup in `apps/agent/src/server/index.ts` does **not** register `@dkg/plugin-epcis` by default.
+- This means `/epcis/*` routes and EPCIS MCP tools are unavailable in the default runtime until the plugin is mounted.
+- `epcis.read` and `epcis.write` are still declared OAuth scopes, but they only take effect for EPCIS once the plugin and HTTP scope guards are enabled.
+
 ## Quick Start
 
-1. Ensure publisher plugin and epcis plugin is enabled in server plugin registration:
-   - `apps/agent/src/server/index.ts` should include `dkgPublisherPlugin` in the `plugins` array.
+1. Enable EPCIS + publisher plugins in server plugin registration (this is not enabled by default in this repo):
    - `apps/agent/src/server/index.ts` should include `epcisPlugin` in the `plugins` array.
+   - `apps/agent/src/server/index.ts` should include `dkgPublisherPlugin` in the `plugins` array.
+   - If you want route-level EPCIS scope enforcement, apply `applyEpcisHttpScopeGuards(api, authorized)` in the auth middleware plugin.
 2. Run publisher plugin setup:
    - `cd packages/plugin-dkg-publisher && npm run setup`
    - This initializes publisher configuration (including `.env.publisher`) for the publisher flow.
@@ -56,13 +63,15 @@ Implementation note: EPCIS MCP tool handlers are guarded with `withRequiredMcpSc
 - `GET /epcis/events`  
   Queries EPCIS events with filtering and pagination.
 
-- `GET /epcis/asset/*ual`  
-  Retrieves an EPCIS asset by UAL.
+- `GET /epcis/events/track`  
+  Tracks a single EPC across all event types using full traceability.
 
 ### MCP Tools
 
 - `epcis-query`
 - `epcis-track-item`
+- `epcis-capture`
+- `epcis-capture-status`
 
 ## Configuration
 
@@ -148,6 +157,7 @@ curl "http://localhost:9200/epcis/events?epc=urn:epc:id:sgtin:4012345.011111.100
 - `POST /epcis/capture` validates the EPCIS document structure before publishing.
 - `GET /epcis/capture/:captureID` expects numeric capture IDs from publisher responses.
 - `GET /epcis/events` rejects invalid pagination and empty-string filter parameters.
+- `GET /epcis/events/track` requires a non-empty `epc` query parameter.
 
 ## Troubleshooting
 

--- a/docs/build-a-dkg-node-ai-agent/plugins/epcis-plugin.md
+++ b/docs/build-a-dkg-node-ai-agent/plugins/epcis-plugin.md
@@ -25,9 +25,22 @@ It provides both HTTP endpoints and MCP tools for:
    - This initializes publisher configuration (including `.env.publisher`) for the publisher flow.
 3. Configure runtime environment:
    - `EXPO_PUBLIC_MCP_URL=http://localhost:9200` (local same-host setup)
-4. Start the DKG Node server.
-5. Submit an EPCIS document via `POST /epcis/capture`.
-6. Query captured events via `GET /epcis/events`.
+4. Create a token with EPCIS scopes:
+   - `cd apps/agent && npm run script:createToken`
+   - Scope input examples:
+     - API only: `epcis.read epcis.write`
+     - MCP tools: `mcp epcis.read epcis.write`
+5. Start the DKG Node server.
+6. Submit an EPCIS document via `POST /epcis/capture`.
+7. Query captured events via `GET /epcis/events`.
+
+EPCIS authorization scopes:
+
+- `epcis.read`: `GET /epcis/events`, `GET /epcis/events/track`, and MCP tools `epcis-query`, `epcis-track-item`
+- `epcis.write`: `POST /epcis/capture`, `GET /epcis/capture/:captureID`, and MCP tools `epcis-capture`, `epcis-capture-status`
+- MCP transport still requires `mcp` scope on `/mcp`
+
+Implementation note: EPCIS MCP tool handlers are guarded with `withRequiredMcpScope(...)` in `packages/plugin-epcis/src/index.ts`, while keeping standard `mcp.registerTool(...)` registration.
 
 ## Capabilities
 
@@ -152,4 +165,3 @@ curl "http://localhost:9200/epcis/events?epc=urn:epc:id:sgtin:4012345.011111.100
 For full EPCIS field-level details and examples, see:
 
 - `packages/plugin-epcis/docs/EPCIS-Integration-Guide.md`
-

--- a/docs/getting-started/security.md
+++ b/docs/getting-started/security.md
@@ -87,10 +87,10 @@ Follow the prompts:
 
 Examples:
 
-- `epcis.read` → EPCIS event read routes only (no MCP)
-- `epcis.write` → EPCIS capture and capture-status routes only (no MCP)
-- `mcp epcis.read` → EPCIS read MCP tools over `/mcp`
-- `mcp epcis.write` → EPCIS capture/capture-status MCP tools over `/mcp`
+- `epcis.read` → EPCIS read scope (effective when EPCIS plugin is enabled)
+- `epcis.write` → EPCIS write scope (effective when EPCIS plugin is enabled)
+- `mcp epcis.read` → EPCIS read MCP tools over `/mcp` (when EPCIS plugin is enabled)
+- `mcp epcis.write` → EPCIS capture/capture-status MCP tools over `/mcp` (when EPCIS plugin is enabled)
 
 **When to use tokens**
 
@@ -112,13 +112,19 @@ DKG Node OAuth Tokens are standard **Bearer tokens**. Include them in the `Autho
 
 Access in the DKG Node is **scope-based**:
 
-- By default:
+- By default in the current `apps/agent/src/server/index.ts` runtime:
   - `/mcp` → requires `mcp` scope
   - `/llm` → requires `llm` scope
   - `/blob` → requires `blob` scope
-  - `GET /epcis/events`, `GET /epcis/events/track` → require `epcis.read`
-  - `POST /epcis/capture`, `GET /epcis/capture/:captureID` → require `epcis.write`
+  - `/change-password` and `/profile` → require authentication (empty scope list)
 - Only users or tokens with those scopes can access the corresponding routes.
+
+EPCIS scopes (`epcis.read`, `epcis.write`) are included in OAuth configuration, but EPCIS routes/tools are available only after the EPCIS plugin is mounted.
+
+When EPCIS is enabled and HTTP guards are applied, this mapping is used:
+
+- `GET /epcis/events`, `GET /epcis/events/track` → `epcis.read`
+- `POST /epcis/capture`, `GET /epcis/capture/:captureID` → `epcis.write`
 
 For EPCIS MCP tools (transported through `/mcp`), `/mcp` still requires `mcp`, and tools additionally require:
 

--- a/docs/getting-started/security.md
+++ b/docs/getting-started/security.md
@@ -12,29 +12,29 @@ Your DKG Node includes a secure, built-in authentication system powered by **OAu
 
 This section will guide you through:
 
-* **Understanding OAuth 2.1** - why it’s used, and how it enables secure integrations with tools like Cursor, VS Code, and Copilot.
-* **Managing users and tokens** - how to create, edit, and assign access scopes through the CLI or **Drizzle Studio**.
-* **Securing custom plugins** - applying scoped authorization so only approved users or agents can access sensitive endpoints.
+- **Understanding OAuth 2.1** - why it’s used, and how it enables secure integrations with tools like Cursor, VS Code, and Copilot.
+- **Managing users and tokens** - how to create, edit, and assign access scopes through the CLI or **Drizzle Studio**.
+- **Securing custom plugins** - applying scoped authorization so only approved users or agents can access sensitive endpoints.
 
 ### OAuth
 
 By default, the DKG Node uses **OAuth 2.1** for authentication, powered by:
 
-* `@dkg/plugin-oauth`
-* `@modelcontextprotocol/sdk` (TypeScript framework)
+- `@dkg/plugin-oauth`
+- `@modelcontextprotocol/sdk` (TypeScript framework)
 
 **Why OAuth 2.1?**
 
-* Recommended standard for AI agent integrations.
-* Works seamlessly with agents like **VS Code/GitHub Copilot**, **Cursor AI Agent mode**, and other OAuth-compatible clients.
-* Supports **Dynamic Client Registration** → AI agents can automatically discover and connect to your DKG Node.
+- Recommended standard for AI agent integrations.
+- Works seamlessly with agents like **VS Code/GitHub Copilot**, **Cursor AI Agent mode**, and other OAuth-compatible clients.
+- Supports **Dynamic Client Registration** → AI agents can automatically discover and connect to your DKG Node.
 
 **User data is managed in a built-in SQLite operational database**, which stores:
 
-* User account information (username & password)
-* Permissions and access scopes
-* OAuth tokens issued by the server
-* Manually created authentication tokens
+- User account information (username & password)
+- Permissions and access scopes
+- OAuth tokens issued by the server
+- Manually created authentication tokens
 
 ### Creating users
 
@@ -48,26 +48,27 @@ npm run script:createUser
 
 Follow the prompts to enter:
 
-* **Username** → unique identifier for the user
-* **Password** → a secure password
-* **Scope(s)** → permissions (e.g., `"mcp llm"` for full access)
+- **Username** → unique identifier for the user
+- **Password** → a secure password
+- **Scope(s)** → permissions (e.g., `"mcp llm"` for full access)
 
 🔍 **Managing users with Drizzle Studio**
 
-* Starts automatically with `npm run dev`
-*   Or run manually:
+- Starts automatically with `npm run dev`
+- Or run manually:
 
-    ```bash
-    npm run drizzle:studio
-    ```
-* Accessible at: [http://local.drizzle.studio](http://local.drizzle.studio/?utm_source=chatgpt.com)
+  ```bash
+  npm run drizzle:studio
+  ```
+
+- Accessible at: [http://local.drizzle.studio](http://local.drizzle.studio/?utm_source=chatgpt.com)
 
 With Drizzle Studio, you can:
 
-* View all users
-* Edit user information
-* Manage permissions/scopes
-* Monitor issued tokens
+- View all users
+- Edit user information
+- Manage permissions/scopes
+- Monitor issued tokens
 
 ### Creating tokens
 
@@ -81,16 +82,23 @@ npm run script:createToken
 
 Follow the prompts:
 
-* **Scope(s)** → define permissions (e.g., `"mcp llm"`) — more on managing permission scopes in the section [#managing-permission-scopes](security.md#managing-permission-scopes "mention") below
-* **Expiration** → choose how long the token should remain valid
+- **Scope(s)** → define permissions (e.g., `"mcp llm epcis.read epcis.write"`) — more on managing permission scopes in the section [#managing-permission-scopes](security.md#managing-permission-scopes "mention") below
+- **Expiration** → choose how long the token should remain valid
+
+Examples:
+
+- `epcis.read` → EPCIS event read routes only (no MCP)
+- `epcis.write` → EPCIS capture and capture-status routes only (no MCP)
+- `mcp epcis.read` → EPCIS read MCP tools over `/mcp`
+- `mcp epcis.write` → EPCIS capture/capture-status MCP tools over `/mcp`
 
 **When to use tokens**
 
-* Giving **agents access** to tools and resources on your DKG Node
-* Automated scripts and integrations
-* Service-to-service communication
-* Testing and development
-* Apps without user interaction
+- Giving **agents access** to tools and resources on your DKG Node
+- Automated scripts and integrations
+- Service-to-service communication
+- Testing and development
+- Apps without user interaction
 
 ### Using a token
 
@@ -104,10 +112,34 @@ DKG Node OAuth Tokens are standard **Bearer tokens**. Include them in the `Autho
 
 Access in the DKG Node is **scope-based**:
 
-* By default:
-  * `/mcp` → requires `mcp` scope
-  * `/llm` → requires `llm` scope
-* Only users or tokens with those scopes can access the corresponding routes.
+- By default:
+  - `/mcp` → requires `mcp` scope
+  - `/llm` → requires `llm` scope
+  - `/blob` → requires `blob` scope
+  - `GET /epcis/events`, `GET /epcis/events/track` → require `epcis.read`
+  - `POST /epcis/capture`, `GET /epcis/capture/:captureID` → require `epcis.write`
+- Only users or tokens with those scopes can access the corresponding routes.
+
+For EPCIS MCP tools (transported through `/mcp`), `/mcp` still requires `mcp`, and tools additionally require:
+
+- `epcis-query`, `epcis-track-item` → `epcis.read`
+- `epcis-capture`, `epcis-capture-status` → `epcis.write`
+
+For custom MCP tools, keep the standard `mcp.registerTool(...)` flow and guard only the handler:
+
+```ts
+import { withRequiredMcpScope } from "@dkg/plugins";
+
+mcp.registerTool(
+  "my-tool",
+  config,
+  withRequiredMcpScope("my.scope", async (input, context) => {
+    return { content: [{ type: "text", text: "ok" }] };
+  }),
+);
+```
+
+This keeps plugin developer ergonomics unchanged while enforcing tool-level scopes.
 
 **IMPORTANT: Custom plugins are not protected automatically**\
 When you create custom plugins, you must **assign scopes,** or they’ll be exposed without protection.
@@ -139,9 +171,6 @@ In this example, only users or tokens with the `customscope` scope can access yo
 
 Scopes are assigned during:
 
-* **User creation** (via `npm run script:createUser`)
-* **Token creation** (via `npm run script:createToken`)
-* Or later, through **Drizzle Studio**.
-
-
-
+- **User creation** (via `npm run script:createUser`)
+- **Token creation** (via `npm run script:createToken`)
+- Or later, through **Drizzle Studio**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
       "dependencies": {
         "@dkg/expo-forcegraph": "^0.0.0",
         "@dkg/plugin-dkg-essentials": "^0.0.3",
-        "@dkg/plugin-epcis": "^0.0.1",
         "@dkg/plugin-example": "^0.0.3",
         "@dkg/plugin-oauth": "^0.0.2",
         "@dkg/plugin-swagger": "^0.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
       "dependencies": {
         "@dkg/expo-forcegraph": "^0.0.0",
         "@dkg/plugin-dkg-essentials": "^0.0.3",
+        "@dkg/plugin-epcis": "^0.0.1",
         "@dkg/plugin-example": "^0.0.3",
         "@dkg/plugin-oauth": "^0.0.2",
         "@dkg/plugin-swagger": "^0.0.2",

--- a/packages/plugin-epcis/docs/EPCIS-Integration-Guide.md
+++ b/packages/plugin-epcis/docs/EPCIS-Integration-Guide.md
@@ -34,6 +34,11 @@ This integration bridges **GS1 EPCIS 2.0** (Electronic Product Code Information 
 - **Publish** them as tamper-proof Knowledge Assets on the DKG
 - **Query** events using semantic filters across the distributed network
 
+### Runtime status in this repository
+
+The current default server setup in `apps/agent/src/server/index.ts` does **not** register `@dkg/plugin-epcis` by default.  
+This guide documents EPCIS behavior **when the EPCIS plugin is mounted** (and, for HTTP scope enforcement, when EPCIS scope guards are applied).
+
 ### Why Use DKG for EPCIS?
 
 | Traditional EPCIS       | EPCIS + DKG                           |
@@ -557,6 +562,9 @@ urn:epc:id:gdti:{CompanyPrefix}.{DocumentType}.{SerialNumber}
 ---
 
 ## 10. API Reference
+
+> The HTTP routes below are available when `@dkg/plugin-epcis` is registered on the server.
+> In this repository's current default runtime, EPCIS routes are not mounted until you enable the plugin.
 
 ### Authorization and required scopes
 

--- a/packages/plugin-epcis/docs/EPCIS-Integration-Guide.md
+++ b/packages/plugin-epcis/docs/EPCIS-Integration-Guide.md
@@ -558,6 +558,26 @@ urn:epc:id:gdti:{CompanyPrefix}.{DocumentType}.{SerialNumber}
 
 ## 10. API Reference
 
+### Authorization and required scopes
+
+All EPCIS HTTP routes require a Bearer token in the `Authorization` header:
+
+```http
+Authorization: Bearer <access-token>
+```
+
+Scope requirements:
+
+- `GET /epcis/events`, `GET /epcis/events/track` -> `epcis.read`
+- `POST /epcis/capture`, `GET /epcis/capture/:captureID` -> `epcis.write`
+
+For MCP usage, `/mcp` still requires `mcp`, and EPCIS tools additionally require:
+
+- `epcis-query`, `epcis-track-item` -> `epcis.read`
+- `epcis-capture`, `epcis-capture-status` -> `epcis.write`
+
+Implementation note: EPCIS MCP tools keep standard `mcp.registerTool(...)` registration and enforce tool-level scopes by wrapping handlers with `withRequiredMcpScope(...)`.
+
 ### POST `/epcis/capture`
 
 Accept an EPCIS Document and queue it for publishing to DKG.
@@ -594,6 +614,8 @@ Accept an EPCIS Document and queue it for publishing to DKG.
 
 | Status                        | When                      | Description                                                             |
 | ----------------------------- | ------------------------- | ----------------------------------------------------------------------- |
+| **401 Unauthorized**          | Missing/invalid token     | No valid Bearer token was provided                                      |
+| **403 Forbidden**             | Missing `epcis.write`     | Token is valid but lacks required write scope                           |
 | **202 Accepted**              | Document valid and queued | Capture forwarded to publisher; includes `captureID` for status polling |
 | **400 Bad Request**           | Validation failed         | GS1 schema validation error or document contains no events              |
 | **500 Internal Server Error** | Publisher unreachable     | Publisher service unavailable after retry attempts                      |
@@ -654,6 +676,8 @@ Check the status of a previously submitted capture tracked by the publisher.
 
 | Status                        | When                     | Description                                         |
 | ----------------------------- | ------------------------ | --------------------------------------------------- |
+| **401 Unauthorized**          | Missing/invalid token    | No valid Bearer token was provided                  |
+| **403 Forbidden**             | Missing `epcis.write`    | Token is valid but lacks required write scope       |
 | **200 OK**                    | Capture found            | Returns current status, optional UAL and timestamps |
 | **404 Not Found**             | Unknown captureID        | No capture with this ID exists in the publisher     |
 | **500 Internal Server Error** | Upstream publisher error | Unexpected publisher/status lookup failure          |
@@ -729,11 +753,13 @@ Query EPCIS events from the DKG using SPARQL.
 
 **Responses:**
 
-| Status                        | When              | Description                                    |
-| ----------------------------- | ----------------- | ---------------------------------------------- |
-| **200 OK**                    | Query succeeded   | Returns matching events with pagination        |
-| **400 Bad Request**           | Validation failed | Missing filters, invalid date range, or params |
-| **500 Internal Server Error** | DKG query failed  | Failed to execute SPARQL query against DKG     |
+| Status                        | When                  | Description                                    |
+| ----------------------------- | --------------------- | ---------------------------------------------- |
+| **401 Unauthorized**          | Missing/invalid token | No valid Bearer token was provided             |
+| **403 Forbidden**             | Missing `epcis.read`  | Token is valid but lacks required read scope   |
+| **200 OK**                    | Query succeeded       | Returns matching events with pagination        |
+| **400 Bad Request**           | Validation failed     | Missing filters, invalid date range, or params |
+| **500 Internal Server Error** | DKG query failed      | Failed to execute SPARQL query against DKG     |
 
 **Example (HTTP 200 OK):**
 
@@ -794,11 +820,13 @@ Track a single EPC through its full supply chain journey. This endpoint always p
 
 **Responses:**
 
-| Status                        | When                  | Description                        |
-| ----------------------------- | --------------------- | ---------------------------------- |
-| **200 OK**                    | Query succeeded       | Returns matching events for EPC    |
-| **400 Bad Request**           | Missing/invalid `epc` | Query validation failed            |
-| **500 Internal Server Error** | DKG query failed      | Failed to execute full-trace query |
+| Status                        | When                  | Description                                  |
+| ----------------------------- | --------------------- | -------------------------------------------- |
+| **401 Unauthorized**          | Missing/invalid token | No valid Bearer token was provided           |
+| **403 Forbidden**             | Missing `epcis.read`  | Token is valid but lacks required read scope |
+| **200 OK**                    | Query succeeded       | Returns matching events for EPC              |
+| **400 Bad Request**           | Missing/invalid `epc` | Query validation failed                      |
+| **500 Internal Server Error** | DKG query failed      | Failed to execute full-trace query           |
 
 **Example (HTTP 200 OK):**
 
@@ -1010,21 +1038,21 @@ Each entry includes:
 
 SPARQL query results (from both the HTTP API and MCP tools) return events with the following fields:
 
-| Field          | Description                                       | Example                                                |
-| -------------- | ------------------------------------------------- | ------------------------------------------------------ |
-| `ual`          | Knowledge Asset graph containing this event       | `did:dkg:otp:2043/0x.../1/private`                     |
-| `eventType`    | Full EPCIS event type URI                         | `https://gs1.github.io/EPCIS/ObjectEvent`              |
-| `eventTime`    | When the event occurred (ISO 8601)                | `2024-03-01T08:00:00.000Z`                             |
-| `bizStep`      | Business step URI                                 | `https://ref.gs1.org/cbv/BizStep-receiving`            |
-| `bizLocation`  | Business location identifier                      | `urn:epc:id:sgln:4012345.00001.0`                      |
-| `disposition`  | Current state/condition URI                       | `https://ref.gs1.org/cbv/Disp-in_progress`             |
-| `readPoint`    | Scan/read location identifier                     | `urn:epc:id:sgln:4012345.00001.0`                      |
-| `action`       | Event action (`ADD`, `OBSERVE`, `DELETE`)          | `ADD`                                                  |
-| `parentID`     | Parent EPC (AggregationEvent)                     | `urn:epc:id:sscc:4012345.0000000001`                   |
-| `epcList`      | Observed EPCs (comma-separated)                   | `urn:epc:id:sgtin:4012345.011111.1001`                 |
-| `childEPCList` | Child EPCs (comma-separated, AggregationEvent)    | `urn:epc:id:sgtin:4012345.099999.9001`                 |
-| `inputEPCs`    | Input EPCs (comma-separated, TransformationEvent) | `urn:epc:id:sgtin:4012345.011111.1001, ...`            |
-| `outputEPCs`   | Output EPCs (comma-separated, TransformationEvent)| `urn:epc:id:sgtin:4012345.099999.9001`                 |
+| Field          | Description                                        | Example                                     |
+| -------------- | -------------------------------------------------- | ------------------------------------------- |
+| `ual`          | Knowledge Asset graph containing this event        | `did:dkg:otp:2043/0x.../1/private`          |
+| `eventType`    | Full EPCIS event type URI                          | `https://gs1.github.io/EPCIS/ObjectEvent`   |
+| `eventTime`    | When the event occurred (ISO 8601)                 | `2024-03-01T08:00:00.000Z`                  |
+| `bizStep`      | Business step URI                                  | `https://ref.gs1.org/cbv/BizStep-receiving` |
+| `bizLocation`  | Business location identifier                       | `urn:epc:id:sgln:4012345.00001.0`           |
+| `disposition`  | Current state/condition URI                        | `https://ref.gs1.org/cbv/Disp-in_progress`  |
+| `readPoint`    | Scan/read location identifier                      | `urn:epc:id:sgln:4012345.00001.0`           |
+| `action`       | Event action (`ADD`, `OBSERVE`, `DELETE`)          | `ADD`                                       |
+| `parentID`     | Parent EPC (AggregationEvent)                      | `urn:epc:id:sscc:4012345.0000000001`        |
+| `epcList`      | Observed EPCs (comma-separated)                    | `urn:epc:id:sgtin:4012345.011111.1001`      |
+| `childEPCList` | Child EPCs (comma-separated, AggregationEvent)     | `urn:epc:id:sgtin:4012345.099999.9001`      |
+| `inputEPCs`    | Input EPCs (comma-separated, TransformationEvent)  | `urn:epc:id:sgtin:4012345.011111.1001, ...` |
+| `outputEPCs`   | Output EPCs (comma-separated, TransformationEvent) | `urn:epc:id:sgtin:4012345.099999.9001`      |
 
 > Array fields (`epcList`, `childEPCList`, `inputEPCs`, `outputEPCs`) are returned as comma-separated strings from the SPARQL `GROUP_CONCAT`. Fields that don't apply to a specific event type will be empty strings.
 
@@ -1032,12 +1060,19 @@ SPARQL query results (from both the HTTP API and MCP tools) return events with t
 
 ## 12. Query Examples
 
+Set a token first (must include the scopes described above):
+
+```bash
+TOKEN="<your-access-token>"
+```
+
 ### Track a Single Item's Journey
 
 Use the dedicated track endpoint for full-trace item tracking:
 
 ```bash
-curl "http://localhost:9200/epcis/events/track?epc=urn:epc:id:sgtin:4012345.011111.1001"
+curl "http://localhost:9200/epcis/events/track?epc=urn:epc:id:sgtin:4012345.011111.1001" \
+  -H "Authorization: Bearer $TOKEN"
 ```
 
 ### Track All Events for a Product
@@ -1045,7 +1080,8 @@ curl "http://localhost:9200/epcis/events/track?epc=urn:epc:id:sgtin:4012345.0111
 Find all events where the carbon frame appears using the general query with full trace:
 
 ```bash
-curl "http://localhost:9200/epcis/events?epc=urn:epc:id:sgtin:4012345.011111.1001&fullTrace=true"
+curl "http://localhost:9200/epcis/events?epc=urn:epc:id:sgtin:4012345.011111.1001&fullTrace=true" \
+  -H "Authorization: Bearer $TOKEN"
 ```
 
 ### Find All Receiving Events

--- a/packages/plugin-epcis/src/httpScopeGuards.ts
+++ b/packages/plugin-epcis/src/httpScopeGuards.ts
@@ -1,0 +1,53 @@
+import type { express } from "@dkg/plugins/types";
+
+type EpcisHttpMethod = "get" | "post";
+type EpcisScope = "epcis.read" | "epcis.write";
+
+export const EPCIS_ROUTE_PATHS = {
+  capture: "/epcis/capture",
+  captureStatus: "/epcis/capture/:captureID",
+  events: "/epcis/events",
+  trackEvents: "/epcis/events/track",
+} as const;
+
+export type EpcisHttpScopeRule = {
+  method: EpcisHttpMethod;
+  path: string;
+  requiredScope: EpcisScope;
+};
+
+export const EPCIS_HTTP_SCOPE_RULES: readonly EpcisHttpScopeRule[] = [
+  {
+    method: "get",
+    path: EPCIS_ROUTE_PATHS.events,
+    requiredScope: "epcis.read",
+  },
+  {
+    method: "get",
+    path: EPCIS_ROUTE_PATHS.trackEvents,
+    requiredScope: "epcis.read",
+  },
+  {
+    method: "get",
+    path: EPCIS_ROUTE_PATHS.captureStatus,
+    requiredScope: "epcis.write",
+  },
+  {
+    method: "post",
+    path: EPCIS_ROUTE_PATHS.capture,
+    requiredScope: "epcis.write",
+  },
+];
+
+type ScopeMiddlewareFactory = (
+  requiredScopes: string[],
+) => express.RequestHandler;
+
+export function applyEpcisHttpScopeGuards(
+  api: express.Router,
+  authorize: ScopeMiddlewareFactory,
+): void {
+  for (const { method, path, requiredScope } of EPCIS_HTTP_SCOPE_RULES) {
+    api[method](path, authorize([requiredScope]));
+  }
+}

--- a/packages/plugin-epcis/src/index.ts
+++ b/packages/plugin-epcis/src/index.ts
@@ -1,4 +1,4 @@
-import { defineDkgPlugin } from "@dkg/plugins";
+import { defineDkgPlugin, withRequiredMcpScope } from "@dkg/plugins";
 import { openAPIRoute, z } from "@dkg/plugin-swagger";
 import type { EpcisQueryParams, ValidationResult } from "./model/types";
 import { EpcisQueryService } from "./services/epcisQueryService";
@@ -297,7 +297,7 @@ export default defineDkgPlugin((ctx, mcp, api) => {
         ),
       },
     },
-    async (input) => {
+    withRequiredMcpScope("epcis.read", async (input) => {
       try {
         if (!hasAtLeastOneEpcisFilter(input)) {
           return mcpError({
@@ -335,7 +335,7 @@ export default defineDkgPlugin((ctx, mcp, api) => {
         console.error("[EPCIS] DKG query failed:", error);
         return mcpError({ error: "Query failed" });
       }
-    },
+    }),
   );
 
   // MCP Tool: Track item journey (full traceability)
@@ -353,7 +353,7 @@ export default defineDkgPlugin((ctx, mcp, api) => {
         ),
       },
     },
-    async (input) => {
+    withRequiredMcpScope("epcis.read", async (input) => {
       try {
         const { resultData, resultCount } = await executeEpcisEventsQuery({
           epc: input.epc,
@@ -376,7 +376,7 @@ export default defineDkgPlugin((ctx, mcp, api) => {
         console.error(`[EPCIS] Item tracking failed, epc: ${input.epc}`, error);
         return mcpError({ error: "Tracking failed" });
       }
-    },
+    }),
   );
 
   // MCP Tool: Capture EPCISDocument and queue for publishing
@@ -396,7 +396,7 @@ export default defineDkgPlugin((ctx, mcp, api) => {
           .optional(),
       },
     },
-    async (input) => {
+    withRequiredMcpScope("epcis.write", async (input) => {
       try {
         const response = await executeCapture(
           input.epcisDocument,
@@ -420,7 +420,7 @@ export default defineDkgPlugin((ctx, mcp, api) => {
         console.error("[EPCIS] MCP capture failed:", error);
         return mcpError({ error: "Capture failed" });
       }
-    },
+    }),
   );
 
   // MCP Tool: Check publisher-tracked status by capture ID
@@ -438,7 +438,7 @@ export default defineDkgPlugin((ctx, mcp, api) => {
           ),
       },
     },
-    async (input) => {
+    withRequiredMcpScope("epcis.write", async (input) => {
       try {
         const captureStatus = await parseCaptureStatus(input.captureID);
         if (captureStatus.notFound) {
@@ -475,7 +475,7 @@ export default defineDkgPlugin((ctx, mcp, api) => {
           captureID: input.captureID,
         });
       }
-    },
+    }),
   );
 
   // POST /epcis/capture - Accept EPCISDocument and queue for publishing

--- a/packages/plugin-epcis/src/index.ts
+++ b/packages/plugin-epcis/src/index.ts
@@ -18,6 +18,13 @@ import {
   requiredNonEmptyString,
 } from "./utils/epcisQueryValidation";
 import { formatSourceKAs } from "./utils/sourceKa";
+import { EPCIS_ROUTE_PATHS } from "./httpScopeGuards";
+
+export {
+  applyEpcisHttpScopeGuards,
+  EPCIS_HTTP_SCOPE_RULES,
+  EPCIS_ROUTE_PATHS,
+} from "./httpScopeGuards";
 
 const QUERY_LIMIT = {
   MIN: 1,
@@ -480,7 +487,7 @@ export default defineDkgPlugin((ctx, mcp, api) => {
 
   // POST /epcis/capture - Accept EPCISDocument and queue for publishing
   api.post(
-    "/epcis/capture",
+    EPCIS_ROUTE_PATHS.capture,
     openAPIRoute(
       {
         tag: "EPCIS",
@@ -564,7 +571,7 @@ export default defineDkgPlugin((ctx, mcp, api) => {
 
   // GET /epcis/capture/:captureID - Check capture status
   api.get(
-    "/epcis/capture/:captureID",
+    EPCIS_ROUTE_PATHS.captureStatus,
     openAPIRoute(
       {
         tag: "EPCIS",
@@ -642,7 +649,7 @@ export default defineDkgPlugin((ctx, mcp, api) => {
 
   // GET /epcis/events - Query EPCIS events from DKG
   api.get(
-    "/epcis/events",
+    EPCIS_ROUTE_PATHS.events,
     openAPIRoute(
       {
         tag: "EPCIS",
@@ -759,7 +766,7 @@ export default defineDkgPlugin((ctx, mcp, api) => {
 
   // GET /epcis/events/track - Track single EPC across full trace
   api.get(
-    "/epcis/events/track",
+    EPCIS_ROUTE_PATHS.trackEvents,
     openAPIRoute(
       {
         tag: "EPCIS",

--- a/packages/plugin-epcis/tests/pluginEpcis.spec.ts
+++ b/packages/plugin-epcis/tests/pluginEpcis.spec.ts
@@ -26,6 +26,7 @@ import {
 } from "@dkg/plugins/testing";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import express from "express";
 
 const story = bicycleStory as any;
@@ -54,14 +55,24 @@ type ToolCallParams = {
   arguments?: Record<string, unknown>;
 };
 
-const MCP_TOOL_AUTH = {
+const MCP_TOOL_AUTH: { authInfo: AuthInfo } = {
   authInfo: {
+    token: "test-token",
+    clientId: "test-client",
     scopes: ["epcis.read", "epcis.write"],
   },
-} as const;
+};
+
+let setMcpClientAuthInfo: ((authInfo?: AuthInfo) => void) | null = null;
 
 function callToolWithAuth(client: Client, params: ToolCallParams) {
-  return client.callTool(params, undefined, MCP_TOOL_AUTH as any);
+  setMcpClientAuthInfo?.(MCP_TOOL_AUTH.authInfo);
+  return client.callTool(params);
+}
+
+function callToolWithoutAuth(client: Client, params: ToolCallParams) {
+  setMcpClientAuthInfo?.(undefined);
+  return client.callTool(params);
 }
 
 describe("@dkg/plugin-epcis checks", function () {
@@ -87,9 +98,11 @@ describe("@dkg/plugin-epcis checks", function () {
     };
     dkgQueryStub = sinon.stub(dkgContext.dkg.graph, "query");
 
-    const { server, client, connect } = await createMcpServerClientPair();
+    const { server, client, connect, setClientAuthInfo } =
+      await createMcpServerClientPair();
     mockMcpServer = server;
     mockMcpClient = client;
+    setMcpClientAuthInfo = setClientAuthInfo;
     apiRouter = express.Router();
     app = createExpressApp();
 
@@ -99,6 +112,7 @@ describe("@dkg/plugin-epcis checks", function () {
   });
 
   afterEach(() => {
+    setMcpClientAuthInfo = null;
     sinon.restore();
     if (originalMcpUrl !== undefined) {
       process.env.EXPO_PUBLIC_MCP_URL = originalMcpUrl;
@@ -560,6 +574,18 @@ describe("@dkg/plugin-epcis checks", function () {
       expect(payload.error).to.include(
         "At least one filter parameter is required.",
       );
+    });
+
+    it("returns Forbidden when MCP auth context is missing", async () => {
+      const result = await callToolWithoutAuth(mockMcpClient, {
+        name: "epcis-query",
+        arguments: { bizStep: "receiving" },
+      });
+      const payload = parseToolResult(result);
+
+      expect(result.isError).to.equal(true);
+      expect(payload.error).to.equal("Forbidden");
+      expect(payload.requiredScope).to.equal("epcis.read");
     });
 
     it("returns MCP error when DKG query fails", async () => {

--- a/packages/plugin-epcis/tests/pluginEpcis.spec.ts
+++ b/packages/plugin-epcis/tests/pluginEpcis.spec.ts
@@ -49,6 +49,21 @@ function expectResponseErrorMessage(
   expect(responseBody.error).to.include(messageFragment);
 }
 
+type ToolCallParams = {
+  name: string;
+  arguments?: Record<string, unknown>;
+};
+
+const MCP_TOOL_AUTH = {
+  authInfo: {
+    scopes: ["epcis.read", "epcis.write"],
+  },
+} as const;
+
+function callToolWithAuth(client: Client, params: ToolCallParams) {
+  return client.callTool(params, undefined, MCP_TOOL_AUTH as any);
+}
+
 describe("@dkg/plugin-epcis checks", function () {
   let mockMcpServer: McpServer;
   let mockMcpClient: Client;
@@ -311,7 +326,7 @@ describe("@dkg/plugin-epcis checks", function () {
   describe("MCP Tools", () => {
     it("epcis-query returns assembly event results", async () => {
       dkgQueryStub.resolves(makeDkgQueryResult(ASSEMBLY_EVENTS));
-      const result = await mockMcpClient.callTool({
+      const result = await callToolWithAuth(mockMcpClient, {
         name: "epcis-query",
         arguments: { bizStep: "assembling" },
       });
@@ -325,7 +340,7 @@ describe("@dkg/plugin-epcis checks", function () {
 
     it("epcis-track-item returns journey timeline with numbered steps", async () => {
       dkgQueryStub.resolves(makeDkgQueryResult(BICYCLE_TRACE_EVENTS));
-      const result = await mockMcpClient.callTool({
+      const result = await callToolWithAuth(mockMcpClient, {
         name: "epcis-track-item",
         arguments: { epc: bicycleEpc },
       });
@@ -345,7 +360,7 @@ describe("@dkg/plugin-epcis checks", function () {
 
     it("epcis-capture captures valid document and returns capture details", async () => {
       fetchStub.resolves(publisherQueuedResponse(501));
-      const result = await mockMcpClient.callTool({
+      const result = await callToolWithAuth(mockMcpClient, {
         name: "epcis-capture",
         arguments: event1,
       });
@@ -359,7 +374,7 @@ describe("@dkg/plugin-epcis checks", function () {
     });
 
     it("epcis-capture returns validation error for invalid document", async () => {
-      const result = await mockMcpClient.callTool({
+      const result = await callToolWithAuth(mockMcpClient, {
         name: "epcis-capture",
         arguments: { epcisDocument: { type: "NotAnEPCIS" } },
       });
@@ -372,7 +387,7 @@ describe("@dkg/plugin-epcis checks", function () {
     it("epcis-capture returns publisher error when publisher is unavailable", async function () {
       this.timeout(15000);
       fetchStub.rejects(new Error("publisher down"));
-      const result = await mockMcpClient.callTool({
+      const result = await callToolWithAuth(mockMcpClient, {
         name: "epcis-capture",
         arguments: event1,
       });
@@ -391,7 +406,7 @@ describe("@dkg/plugin-epcis checks", function () {
           "2024-03-01T16:30:00.000Z",
         ),
       );
-      const result = await mockMcpClient.callTool({
+      const result = await callToolWithAuth(mockMcpClient, {
         name: "epcis-capture-status",
         arguments: { captureID: "123" },
       });
@@ -405,7 +420,7 @@ describe("@dkg/plugin-epcis checks", function () {
 
     it("epcis-capture-status returns error when capture is not found", async () => {
       fetchStub.resolves(jsonResponse({ error: "not found" }, 404));
-      const result = await mockMcpClient.callTool({
+      const result = await callToolWithAuth(mockMcpClient, {
         name: "epcis-capture-status",
         arguments: { captureID: "404" },
       });
@@ -418,7 +433,7 @@ describe("@dkg/plugin-epcis checks", function () {
 
     it("epcis-capture-status returns timeout error on publisher timeout", async () => {
       fetchStub.rejects(new DOMException("Timed out", "TimeoutError"));
-      const result = await mockMcpClient.callTool({
+      const result = await callToolWithAuth(mockMcpClient, {
         name: "epcis-capture-status",
         arguments: { captureID: "888" },
       });
@@ -434,7 +449,7 @@ describe("@dkg/plugin-epcis checks", function () {
     it("returns the same query event data for epcis-query and GET /epcis/events", async () => {
       dkgQueryStub.resolves(makeDkgQueryResult(ASSEMBLY_EVENTS));
 
-      const mcpResult = await mockMcpClient.callTool({
+      const mcpResult = await callToolWithAuth(mockMcpClient, {
         name: "epcis-query",
         arguments: { bizStep: "assembling" },
       });
@@ -453,7 +468,7 @@ describe("@dkg/plugin-epcis checks", function () {
       fetchStub.onFirstCall().resolves(publisherQueuedResponse(777));
       fetchStub.onSecondCall().resolves(publisherQueuedResponse(777));
 
-      const mcpResult = await mockMcpClient.callTool({
+      const mcpResult = await callToolWithAuth(mockMcpClient, {
         name: "epcis-capture",
         arguments: event1,
       });
@@ -535,7 +550,7 @@ describe("@dkg/plugin-epcis checks", function () {
     });
 
     it("returns MCP error when epcis-query has no filters", async () => {
-      const result = await mockMcpClient.callTool({
+      const result = await callToolWithAuth(mockMcpClient, {
         name: "epcis-query",
         arguments: {},
       });
@@ -549,7 +564,7 @@ describe("@dkg/plugin-epcis checks", function () {
 
     it("returns MCP error when DKG query fails", async () => {
       dkgQueryStub.rejects(new Error("query exploded"));
-      const result = await mockMcpClient.callTool({
+      const result = await callToolWithAuth(mockMcpClient, {
         name: "epcis-query",
         arguments: { bizStep: "receiving" },
       });

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -5,6 +5,7 @@ import compression from "compression";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { registerMcp } from "./registerMcp";
 import { BlobStorage } from "./types";
+export { withRequiredMcpScope } from "./mcpScopeGuard";
 
 //@ts-ignore
 import type DKG from "dkg.js";

--- a/packages/plugins/src/mcpScopeGuard.ts
+++ b/packages/plugins/src/mcpScopeGuard.ts
@@ -15,10 +15,9 @@ export type McpScopeDeniedResult = {
 };
 
 export type McpScopeGuardOptions<Output = unknown> = {
+  // Fail-closed by default. Set true only for trusted non-authenticated flows.
   allowWhenScopeContextMissing?: boolean;
-  onMissingScope?: (
-    requiredScope: string,
-  ) => Output | McpScopeDeniedResult;
+  onMissingScope?: (requiredScope: string) => Output | McpScopeDeniedResult;
 };
 
 function getScopesFromContext(context: unknown): string[] | undefined {
@@ -64,7 +63,7 @@ export function withRequiredMcpScope<TInput, TResult>(
   // 2) If missing/insufficient, return missing-scope response.
   // 3) Otherwise execute the original handler.
   const {
-    allowWhenScopeContextMissing: allowWithoutScopeContext = true,
+    allowWhenScopeContextMissing: allowWithoutScopeContext = false,
     onMissingScope = createDefaultMissingScopeError,
   } = options;
 

--- a/packages/plugins/src/mcpScopeGuard.ts
+++ b/packages/plugins/src/mcpScopeGuard.ts
@@ -1,0 +1,89 @@
+type AuthContext = {
+  authInfo?: {
+    scopes?: string[];
+  };
+  extra?: {
+    authInfo?: {
+      scopes?: string[];
+    };
+  };
+};
+
+export type McpScopeDeniedResult = {
+  content: { type: "text"; text: string }[];
+  isError: true;
+};
+
+export type McpScopeGuardOptions<Output = unknown> = {
+  allowWhenScopeContextMissing?: boolean;
+  onMissingScope?: (
+    requiredScope: string,
+  ) => Output | McpScopeDeniedResult;
+};
+
+function getScopesFromContext(context: unknown): string[] | undefined {
+  const typedContext = context as AuthContext;
+  const scopes =
+    typedContext?.authInfo?.scopes ?? typedContext?.extra?.authInfo?.scopes;
+  return Array.isArray(scopes) ? scopes : undefined;
+}
+
+function createDefaultMissingScopeError(
+  requiredScope: string,
+): McpScopeDeniedResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            error: "Forbidden",
+            statusCode: 403,
+            message: `Missing required scope: ${requiredScope}`,
+            requiredScope,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+    isError: true,
+  };
+}
+
+export function withRequiredMcpScope<TInput, TResult>(
+  requiredScope: string,
+  handler: (input: TInput, context: unknown) => Promise<TResult> | TResult,
+  options: McpScopeGuardOptions<TResult> = {},
+): (
+  input: TInput,
+  context: unknown,
+) => Promise<TResult | McpScopeDeniedResult> {
+  // Flow:
+  // 1) Read scopes from context.
+  // 2) If missing/insufficient, return missing-scope response.
+  // 3) Otherwise execute the original handler.
+  const {
+    allowWhenScopeContextMissing: allowWithoutScopeContext = true,
+    onMissingScope = createDefaultMissingScopeError,
+  } = options;
+
+  return async (
+    input: TInput,
+    context: unknown,
+  ): Promise<TResult | McpScopeDeniedResult> => {
+    const scopes = getScopesFromContext(context);
+    if (!scopes) {
+      if (allowWithoutScopeContext) {
+        return handler(input, context);
+      }
+      return onMissingScope(requiredScope);
+    }
+
+    if (!scopes.includes(requiredScope)) {
+      return onMissingScope(requiredScope);
+    }
+
+    return handler(input, context);
+  };
+}

--- a/packages/plugins/src/testing.ts
+++ b/packages/plugins/src/testing.ts
@@ -1,6 +1,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { createBlobStorage, express } from "./helpers";
 import { BlobData, BlobMetadata } from "./types";
 
@@ -36,12 +37,26 @@ export const createExpressApp = () => {
 export const createMcpServerClientPair = async () => {
   const server = new McpServer({ name: "Test DKG Server", version: "1.0.0" });
   const client = new Client({ name: "Test DKG Client", version: "1.0.0" });
-  const [serverTransport, clientTransport] =
+  const [clientTransport, serverTransport] =
     InMemoryTransport.createLinkedPair();
+  let authInfoForClientMessages: AuthInfo | undefined;
+
+  const originalClientSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message, options) => {
+    return originalClientSend(message, {
+      ...options,
+      authInfo: options?.authInfo ?? authInfoForClientMessages,
+    });
+  };
 
   return {
     server,
     client,
+    clientTransport,
+    serverTransport,
+    setClientAuthInfo: (authInfo?: AuthInfo) => {
+      authInfoForClientMessages = authInfo;
+    },
     connect: () =>
       Promise.all([
         server.connect(serverTransport),


### PR DESCRIPTION
Add withRequiredMcpScope support in @dkg/plugins and apply it to EPCIS MCP handlers while preserving the standard mcp.registerTool flow. Expand integration tests and documentation to cover MCP transport scope plus tool-level epcis.read/epcis.write requirements.